### PR TITLE
No need to pass http/https proxy info seperately.

### DIFF
--- a/siteinfo.py
+++ b/siteinfo.py
@@ -918,12 +918,11 @@ class Site(object):
             proxy = urllib2.ProxyHandler()
             opener = urllib2.build_opener(proxy)
         else:
-            if re.match("^https://", self.FullURL):
-                proxy = urllib2.ProxyHandler({'https' : self.Proxy})
-                opener = urllib2.build_opener(proxy)
-            else:
-                proxy = urllib2.ProxyHandler({'http' : self.Proxy})
-                opener = urllib2.build_opener(proxy)
+            proxy = urllib2.ProxyHandler({
+                'https': self.Proxy,
+                'http': self.Proxy
+            })
+            opener = urllib2.build_opener(proxy)
         opener.addheaders = [('User-agent', self.UserAgent)]
         try:
             response = opener.open(self.FullURL)
@@ -1285,12 +1284,11 @@ class PostTransactionPositiveCapableSite(Site):
             proxy = urllib2.ProxyHandler()
             opener = urllib2.build_opener(proxy)
         else:
-            if re.match("^https://", self.FullURL):
-                proxy = urllib2.ProxyHandler({'https' : self.Proxy})
-                opener = urllib2.build_opener(proxy)
-            else:
-                proxy = urllib2.ProxyHandler({'http' : self.Proxy})
-                opener = urllib2.build_opener(proxy)
+            proxy = urllib2.ProxyHandler({
+                'https': self.Proxy,
+                'http': self.Proxy
+            })
+            opener = urllib2.build_opener(proxy)
         opener.addheaders = [('User-agent', self.UserAgent)]
         try:
             url = (self.URL)
@@ -1425,12 +1423,11 @@ class PostTransactionAPIKeySite(Site):
             proxy = urllib2.ProxyHandler()
             opener = urllib2.build_opener(proxy)
         else:
-            if re.match("^https://", self.FullURL):
-                proxy = urllib2.ProxyHandler({'https' : self.Proxy})
-                opener = urllib2.build_opener(proxy)
-            else:
-                proxy = urllib2.ProxyHandler({'http' : self.Proxy})
-                opener = urllib2.build_opener(proxy)
+            proxy = urllib2.ProxyHandler({
+                'https': self.Proxy,
+                'http': self.Proxy
+            })
+            opener = urllib2.build_opener(proxy)
         opener.addheaders = [('User-agent', self.UserAgent)]
         try:
             url = (self.FullURL)


### PR DESCRIPTION
Just a little cleanup of the `ProxyHandler()` code.  Instead of doing a regex, just supply both protocols to the `ProxyHandler` and it will use the appropriate proxy depending on the protocol it needs.
