### PR TITLE
Use HTTPS when possible

### DIFF
--- a/sites.xml
+++ b/sites.xml
@@ -118,7 +118,7 @@
         <sitetype>
 		<entry>ip</entry>
 	</sitetype>
-        <domainurl>http://robtex.com/</domainurl>
+        <domainurl>https://robtex.com/</domainurl>
         <reportstringforresult>
 		<entry>[+] A records from Robtex.com:</entry>
 	</reportstringforresult>
@@ -303,6 +303,7 @@
         <sitetype>
     	    <entry>md5</entry>
     	</sitetype>
+		<!--supports TLS but uses an invalid cert-->
         <domainurl>http://vxvault.siri-urz.net/</domainurl>
         <reportstringforresult>
     	    <entry>[+] Date found at VXVault:</entry>
@@ -468,6 +469,7 @@
 	<headers></headers>
 	<apikey></apikey>
     </site>
+	<!--supports TLS but uses an invalid cert-->
     <site name="ReputationAuthority">
         <sitetype>
 		<entry>ip</entry>
@@ -570,6 +572,7 @@
 	<sitetype>
 		<entry>ip</entry>
 	</sitetype>
+	<!--supports TLS but uses an invalid cert-->
         <domainurl>http://totalhash.com/</domainurl>
         <reportstringforresult>
 			<entry>[+] Totalhash:</entry>

--- a/sites.xml
+++ b/sites.xml
@@ -43,7 +43,7 @@
           <entry>ThreatType</entry>
       </sitefriendlyname>
       <regex>
-          <entry>This Should Never Ever Ever Match! We don't want not stinking POST requests</entry>
+          <entry>This Should Never Ever Ever Match! We don't want no stinking POST requests</entry>
           <entry>dga_score: (\d+\.\d+)</entry>
           <entry>perplexity: (\d+\.\d+)</entry>
           <entry>entropy: (\d+\.\d+)</entry>
@@ -100,7 +100,7 @@
           <entry/>
       </sitefriendlyname>
       <regex>
-          <entry>This Should Never Ever Ever Match! We don't want not stinking POST requests</entry>
+          <entry>This Should Never Ever Ever Match! We don't want no stinking POST requests</entry>
           <entry>"name":"([^"]+)"</entry>
       </regex>
       <fullurl>https://investigate.api.opendns.com/ips/%TARGET%/latest_domains</fullurl>

--- a/sites.xml
+++ b/sites.xml
@@ -141,7 +141,7 @@
 		<entry>ip</entry>
 		<entry>hostname</entry>
 	</sitetype>
-        <domainurl>http://fortiguard.com/</domainurl>
+        <domainurl>https://fortiguard.com/</domainurl>
         <reportstringforresult>
 		<entry>[+] Fortinet URL Category:</entry>
 	</reportstringforresult>
@@ -151,7 +151,7 @@
         <regex>
 		<entry>Category:\s(.+)\&lt;\/h3\&gt;\s\&lt;a</entry>
 	</regex>
-	<fullurl>http://www.fortiguard.com/ip_rep/index.php?data=%TARGET%&amp;lookup=Lookup</fullurl>
+	<fullurl>https://www.fortiguard.com/ip_rep/index.php?data=%TARGET%&amp;lookup=Lookup</fullurl>
         <importantproperty>
 		<entry>Results</entry>
 	</importantproperty>
@@ -430,7 +430,7 @@
 		<entry>hostname</entry>
 		<entry>md5</entry>
 	</sitetype>
-        <domainurl>http://malc0de.com</domainurl>
+        <domainurl>https://malc0de.com</domainurl>
         <reportstringforresult>
 		<entry>[+] Malc0de Date:</entry>
 		<entry>[+] Malc0de IP:</entry>
@@ -455,7 +455,7 @@
 		<entry>search=\d{4,5}..([A-Za-z]+)</entry>
 		<entry>latest\-scan\/([A-Fa-f0-9]{32})</entry>
 	</regex>
-	<fullurl>http://malc0de.com/database/index.php?search=%TARGET%</fullurl>
+	<fullurl>https://malc0de.com/database/index.php?search=%TARGET%</fullurl>
         <importantproperty>
 		<entry>Results</entry>
 		<entry>Results</entry>
@@ -472,7 +472,7 @@
         <sitetype>
 		<entry>ip</entry>
 	</sitetype>
-        <domainurl>http://http://www.reputationauthority.org</domainurl>
+        <domainurl>http://www.reputationauthority.org</domainurl>
         <reportstringforresult>
 		<entry>[+] Reputation Authority Score:</entry>
 	</reportstringforresult>
@@ -494,7 +494,7 @@
         <sitetype>
                 <entry>ip</entry>
         </sitetype>
-        <domainurl>http://freegeoip.net</domainurl>
+        <domainurl>https://freegeoip.net</domainurl>
         <reportstringforresult>
                 <entry>[+] FreeGeoIP Country Name:</entry>
                 <entry>[+] FreeGeoIP Region Name:</entry>
@@ -519,7 +519,7 @@
                 <entry>latitude\"\:(.+)\,\"long</entry>
                 <entry>longitude\"\:(.+)\,\"metro</entry>
         </regex>
-        <fullurl>http://freegeoip.net/json/%TARGET%</fullurl>
+        <fullurl>https://freegeoip.net/json/%TARGET%</fullurl>
         <importantproperty>
                 <entry>Results</entry>
                 <entry>Results</entry>
@@ -570,7 +570,7 @@
 	<sitetype>
 		<entry>ip</entry>
 	</sitetype>
-        <domainurl>https://totalhash.com/</domainurl>
+        <domainurl>http://totalhash.com/</domainurl>
         <reportstringforresult>
 			<entry>[+] Totalhash:</entry>
 		</reportstringforresult>


### PR DESCRIPTION
A few sites that supported https were not using it in Automater, so I made a quick fix for that.

There's also a few sites that support tls but currently have invalid certificates which I noted in some comments in sites.xml. It's possible to modify these sites to use https if a user so desires since Automater (and from my understanding Python 2) doesn't currently have a way to check the validity of a certificates.