### PR TITLE
Add stdout output options

### DIFF
--- a/Automater.py
+++ b/Automater.py
@@ -32,6 +32,7 @@ Exception(s):
 No exceptions exported.
 """
 
+import logging
 import sys
 from siteinfo import SiteFacade
 from utilities import Parser, IPWrapper
@@ -53,6 +54,11 @@ def main():
     """
     sites = []
     parser = Parser('IP, URL, and Hash Passive Analysis tool')
+
+    if parser.QuietMode:
+        logging.basicConfig(level=logging.ERROR, format="%(message)s")
+    else:
+        logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
     # if no target run and print help
     if parser.hasNoTarget():

--- a/inputs.py
+++ b/inputs.py
@@ -18,7 +18,10 @@ Exception(s):
 No exceptions exported.
 """
 from xml.etree.ElementTree import ElementTree
+import logging
 import os
+
+logger = logging.getLogger("Automater")
 
 class TargetFile(object):
     """
@@ -55,7 +58,7 @@ class TargetFile(object):
                     target = str(i).strip()
                     yield target
         except IOError:
-            print "There was an error reading from the target input file."
+            logger.error("There was an error reading from the target input file.")
 
 
 class SitesFile(object):
@@ -93,8 +96,8 @@ class SitesFile(object):
                 sitetree.parse(f)
                 return sitetree
         except:
-            print "There was an error reading from the sites input file.",
-            print "Please check that the XML file is present and correctly formatted."
+            logger.error("There was an error reading from the sites input file."
+                "Please check that the XML file is present and correctly formatted.")
 
     @classmethod
     def fileExists(self):

--- a/outputs.py
+++ b/outputs.py
@@ -19,8 +19,11 @@ import csv
 import socket
 import re
 import sys
+import logging
 from datetime import datetime
 from operator import attrgetter
+
+logger = logging.getLogger("Automater")
 
 class SiteDetailOutput(object):
     """
@@ -82,7 +85,8 @@ class SiteDetailOutput(object):
         Restriction(s):
         The Method has no restrictions.
         """
-        self.PrintToScreen()
+        if not parser.QuietMode:
+            self.PrintToScreen()
         if parser.hasCEFOutFile():
             self.PrintToCEFFile(parser.CEFOutFile)
         if parser.hasTextOutFile():
@@ -195,7 +199,7 @@ class SiteDetailOutput(object):
                        cef_SignatureID, cef_Severity, cef_Extension]
         pattern = "^\[\+\]\s+"
         target = ""
-        print '\n[+] Generating CEF output: ' + cefoutfile
+        logger.debug("[+] Generating CEF output: {0}".format(cefoutfile))
         if cefoutfile == "-":
             f = sys.stdout
         else:
@@ -294,7 +298,7 @@ class SiteDetailOutput(object):
         if cefoutfile != "-":
             f.flush()
             f.close()
-        print "" + cefoutfile + " Generated"
+        logger.debug("{0} Generated".format(cefoutfile))
 
 
     def PrintToTextFile(self,textoutfile):
@@ -313,7 +317,7 @@ class SiteDetailOutput(object):
         """
         sites = sorted(self.ListOfSites, key=attrgetter('Target'))
         target = ""
-        print "\n[+] Generating text output: " + textoutfile
+        logger.debug("[+] Generating text output: {0}".format(textoutfile))
         if textoutfile == "-":
             f = sys.stdout
         else:
@@ -368,7 +372,7 @@ class SiteDetailOutput(object):
         if textoutfile != "-":
             f.flush()
             f.close()
-        print "" + textoutfile + " Generated"
+        logger.debug("{0} Generated".format(textoutfile))
 
     def PrintToCSVFile(self,csvoutfile):
         """
@@ -386,7 +390,7 @@ class SiteDetailOutput(object):
         """
         sites = sorted(self.ListOfSites, key=attrgetter('Target'))
         target = ""
-        print '\n[+] Generating CSV output: ' + csvoutfile
+        logger.debug("[+] Generating CSV output: {0}".format(csvoutfile))
         if csvoutfile == "-":
             f = sys.stdout
         else:
@@ -466,7 +470,7 @@ class SiteDetailOutput(object):
         if csvoutfile != "-":
             f.flush()
             f.close()
-        print "" + csvoutfile + " Generated"
+        logger.debug("{0} Generated".format(csvoutfile))
 
     def PrintToHTMLFile(self,htmloutfile):
         """
@@ -484,7 +488,7 @@ class SiteDetailOutput(object):
         """
         sites = sorted(self.ListOfSites, key=attrgetter('Target'))
         target = ""
-        print '\n[+] Generating HTML output: ' + htmloutfile
+        logger.debug("[+] Generating HTML output: {0}".format(htmloutfile))
         if htmloutfile == "-":
             f = sys.stdout
         else:
@@ -557,7 +561,7 @@ class SiteDetailOutput(object):
         if htmloutfile != "-":
             f.flush()
             f.close()
-        print "" + htmloutfile + " Generated"
+        logger.debug("{0} Generated".format(htmloutfile))
 
     def getHTMLOpening(self):
         """

--- a/outputs.py
+++ b/outputs.py
@@ -18,6 +18,7 @@ No exceptions exported.
 import csv
 import socket
 import re
+import sys
 from datetime import datetime
 from operator import attrgetter
 
@@ -195,7 +196,10 @@ class SiteDetailOutput(object):
         pattern = "^\[\+\]\s+"
         target = ""
         print '\n[+] Generating CEF output: ' + cefoutfile
-        f = open(cefoutfile, "wb")
+        if cefoutfile == "-":
+            f = sys.stdout
+        else:
+            f = open(cefoutfile, "wb")
         csv.register_dialect('escaped',delimiter='|',escapechar='\\',doublequote=False,quoting=csv.QUOTE_NONE)
         cefRW = csv.writer(f,'escaped')
         #cefRW.writerow(['Target', 'Type', 'Source', 'Result'])
@@ -287,8 +291,9 @@ class SiteDetailOutput(object):
                                            [cef_Severity] + [tgt])
                                     laststring = "" + tgt + typ + source + str(res)
                                     
-        f.flush()
-        f.close()
+        if cefoutfile != "-":
+            f.flush()
+            f.close()
         print "" + cefoutfile + " Generated"
 
 
@@ -309,7 +314,10 @@ class SiteDetailOutput(object):
         sites = sorted(self.ListOfSites, key=attrgetter('Target'))
         target = ""
         print "\n[+] Generating text output: " + textoutfile
-        f = open(textoutfile, "w")
+        if textoutfile == "-":
+            f = sys.stdout
+        else:
+            f = open(textoutfile, "w")
         if sites is not None:
             for site in sites:
                 if not isinstance(site._regex,basestring): #this is a multisite
@@ -357,8 +365,9 @@ class SiteDetailOutput(object):
                                 if "" + site.ReportStringForResult + " " + str(siteresult) != laststring:
                                     f.write("\n" + site.ReportStringForResult + " " + str(siteresult))
                                     laststring = "" + site.ReportStringForResult + " " + str(siteresult)
-        f.flush()
-        f.close()
+        if textoutfile != "-":
+            f.flush()
+            f.close()
         print "" + textoutfile + " Generated"
 
     def PrintToCSVFile(self,csvoutfile):
@@ -378,7 +387,10 @@ class SiteDetailOutput(object):
         sites = sorted(self.ListOfSites, key=attrgetter('Target'))
         target = ""
         print '\n[+] Generating CSV output: ' + csvoutfile
-        f = open(csvoutfile, "wb")
+        if csvoutfile == "-":
+            f = sys.stdout
+        else:
+            f = open(csvoutfile, "wb")
         csvRW = csv.writer(f, quoting=csv.QUOTE_ALL)
         csvRW.writerow(['Target', 'Type', 'Source', 'Result'])
         if sites is not None:
@@ -451,8 +463,9 @@ class SiteDetailOutput(object):
                                     csvRW.writerow([tgt,typ,source,res])
                                     laststring = "" + tgt + typ + source + str(res)
                                     
-        f.flush()
-        f.close()
+        if csvoutfile != "-":
+            f.flush()
+            f.close()
         print "" + csvoutfile + " Generated"
 
     def PrintToHTMLFile(self,htmloutfile):
@@ -472,7 +485,10 @@ class SiteDetailOutput(object):
         sites = sorted(self.ListOfSites, key=attrgetter('Target'))
         target = ""
         print '\n[+] Generating HTML output: ' + htmloutfile
-        f = open(htmloutfile, "w")
+        if htmloutfile == "-":
+            f = sys.stdout
+        else:
+            f = open(htmloutfile, "w")
         f.write(self.getHTMLOpening())
         if sites is not None:
             for site in sites:
@@ -538,8 +554,9 @@ class SiteDetailOutput(object):
                                 tableData = '<tr><td>' + tgt + '</td><td>' + typ + '</td><td>' + source + '</td><td>' + str(res) + '</td></tr>'
                                 f.write(tableData)
         f.write(self.getHTMLClosing())
-        f.flush()
-        f.close()
+        if htmloutfile != "-":
+            f.flush()
+            f.close()
         print "" + htmloutfile + " Generated"
 
     def getHTMLOpening(self):

--- a/siteinfo.py
+++ b/siteinfo.py
@@ -33,9 +33,12 @@ import urllib
 import urllib2
 import time
 import re
+import logging
 from operator import attrgetter
 from inputs import SitesFile
 from utilities import Parser
+
+logger = logging.getLogger("Automater")
 
 class SiteFacade(object):
     """
@@ -824,7 +827,7 @@ class Site(object):
         The Method has no restrictions.
         """
         self._messagetopost = message
-        print self.MessageToPost
+        logger.info(self.MessageToPost)
 
     def getImportantProperty(self, index):
         """
@@ -1140,7 +1143,7 @@ class PostTransactionPositiveCapableSite(Site):
             content = self.getContent()
             if content != None:
                 if self.postIsNecessary(regextofindforpost, content) and self.Params is not None and self.Headers is not None:
-                    print '[-] This target requires a submission. Submitting now, this may take a moment.'
+                    logger.warn("[-] This target requires a submission. Submitting now, this may take a moment.")
                     content = self.submitPost(self.Params, self.Headers)
                 else:
                     pass

--- a/utilities.py
+++ b/utilities.py
@@ -42,6 +42,7 @@ class Parser(object):
     hasPost
     (Property) InputFile
     (Property) UserAgent
+    (Property) QuietMode
 
     Instance variable(s):
     _parser
@@ -70,6 +71,7 @@ class Parser(object):
         self._parser.add_argument('--p', '--post', action = "store_true", help = 'This option tells the program to post information to sites that allow posting. By default the program will NOT post to sites that require a post.')
         self._parser.add_argument('--proxy', help = 'This option will set a proxy to use (eg. proxy.example.com:8080)')
         self._parser.add_argument('-a', '--useragent', default = 'Automater/2.1', help = 'This option allows the user to set the user-agent seen by web servers being utilized. By default, the user-agent is set to Automater/version')
+        self._parser.add_argument('-q', '--quiet', default=False, help = 'This option suppresses all console output, unless stdout is used as an output file for one of the other options', action='store_true')
         self.args = self._parser.parse_args()
 
     def hasCEFOutFile(self):
@@ -483,6 +485,13 @@ class Parser(object):
         This Method is tagged as a Property.
         """
         return self.args.useragent
+
+    @property
+    def QuietMode(self):
+        """
+
+        """
+        return self.args.quiet
 
 class IPWrapper(object):
     """


### PR DESCRIPTION
These commits should add the ability to pass "-" as the filename to all of the output options (CEF, CSV, HTML, text) that will write the output to stdout instead of a file. Additionally, it converts most print statements used for progress messages and adds a -q/--quiet option which suppresses these progress messages.