### PR TITLE
VirusTotal regex: always skip the first result

### DIFF
--- a/tekdefense.xml
+++ b/tekdefense.xml
@@ -140,7 +140,7 @@
             <entry>scan_date....(.{18,25})\"\,</entry>
             <entry>positives...(\d{1,2})\,</entry>
             <entry>total...(\d{1,2})\,</entry>
-            <entry>\}\,\s\"(.{3,20})\"....detected...true.{19,32}result....(.{11,30})....update</entry>
+            <entry>\"([^"]{1,20})\"....detected...true.{19,32}result....([^"]{8,50})....update[^\}]*\}</entry>
         </regex>
         <fullurl>https://www.virustotal.com/vtapi/v2/file/report</fullurl>
         <importantproperty>


### PR DESCRIPTION
i.e. this is part of the raw answer from VirusTotal:
........{"scans": {"Bkav": {"detected": true, "version": "1.3.0.8021", "result": "W32.HfsAdware.578C", "update": "20160519"}, "TotalDefense": {"detecte........
And the regex starts with: '}\,........', so it will skip the 'Bkav' result.