### PR TITLE
Changed the xml files default lookup location

### DIFF
--- a/inputs.py
+++ b/inputs.py
@@ -20,14 +20,16 @@ No exceptions exported.
 import os
 import hashlib
 import requests
+import sys
 from outputs import SiteDetailOutput
 from requests.exceptions import ConnectionError
 from requests.exceptions import HTTPError
 from xml.etree.ElementTree import ElementTree
 
 __REMOTE_TEKD_XML_LOCATION__ = 'https://raw.githubusercontent.com/1aN0rmus/TekDefense-Automater/master/tekdefense.xml'
-__TEKDEFENSEXML__ = 'tekdefense.xml'
-
+__EXECUTION_PATH__ = os.path.dirname(os.path.realpath(sys.argv[0]))
+__TEKDEFENSEXML__ = os.path.join(__EXECUTION_PATH__,
+                                 'tekdefense.xml')
 class TargetFile(object):
     """
     TargetFile provides a Class Method to retrieve information from a file-

--- a/siteinfo.py
+++ b/siteinfo.py
@@ -29,6 +29,7 @@ import requests
 import re
 import time
 import os
+import sys
 from os import listdir
 from os.path import isfile, join
 from requests.exceptions import ConnectionError
@@ -38,7 +39,10 @@ from utilities import VersionChecker
 
 requests.packages.urllib3.disable_warnings()
 
-__TEKDEFENSEXML__ = 'tekdefense.xml'
+
+__EXECUTION_PATH__ = os.path.dirname(os.path.realpath(sys.argv[0]))
+__TEKDEFENSEXML__ = os.path.join(__EXECUTION_PATH__,
+                                 'tekdefense.xml')
 __SITESXML__ = 'sites.xml'
 
 class SiteFacade(object):


### PR DESCRIPTION
The script now looks for the XML files in the install dir, not in the current working directory. This allows you to run the script without being in the install dir.

This will be helpful is you want to install the script somewhere and have an alias to it, or to put a symlink somewhere in your path.