### PR TITLE
VirusTotal regex: skips shortest description from AV Cylance: Unsafe

### DIFF
--- a/tekdefense.xml
+++ b/tekdefense.xml
@@ -140,7 +140,7 @@
             <entry>scan_date....(.{18,25})\"\,</entry>
             <entry>positives...(\d{1,2})\,</entry>
             <entry>total...(\d{1,2})\,</entry>
-            <entry>\"([^"]{1,20})\"....detected...true.{19,32}result....([^"]{8,50})....update[^\}]*\}</entry>
+            <entry>\"([^"]{1,20})\"....detected...true.{19,32}result....([^"]{6,50})....update[^\}]*\}</entry>
         </regex>
         <fullurl>https://www.virustotal.com/vtapi/v2/file/report</fullurl>
         <importantproperty>


### PR DESCRIPTION
Yes, only 6 letters. Very descriptive. Example:
8CA2C261AB69D0195BED81E58EDF167D"
{"scans": {"Bkav": {"detected": false, "version": "1.3.0.9899", "result": null, "update": "20190219"}, "MicroWorld-eScan": {"detected": false, "version": "14.0.297.0", "result": null, "update": "20190219"}, "CMC": {"detected": false, "version": "1.1.0.977", "result": null, "update": "20190219"}, "CAT-QuickHeal": {"detected": false, "version": "14.00", "result": null, "update": "20190219"}, "McAfee": {"detected": false, "version": "6.0.6.653", "result": null, "update": "20190219"}, "Cylance": {"detected": true, "version": "2.3.1.101", "result": **"Unsafe"**, "update": "20190219"},......
